### PR TITLE
Match definitions by args

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -739,7 +739,7 @@ angular.module('js-data-mocks', ['js-data'])
           for (var i = 0; i < definitions.length; i++) {
             let definition = definitions[i];
 
-            if (definition.match(name, resourceName)) {
+            if (definition.match(name, resourceName) && definition.matchArgs(args)) {
               if (definition.response) {
                 responses.push(this.createResponse(resourceName, deferred, definition.response));
                 return deferred.promise;

--- a/test/test.js
+++ b/test/test.js
@@ -58,3 +58,34 @@ describe('test', function () {
     assert.equal(DS.find.callCount, 4);
   });
 });
+
+describe('definitions', function () {
+  var $q;
+  var DS;
+
+  beforeEach(inject(function(_$q_, _DS_) {
+    $q = _$q_;
+    DS = _DS_;
+  }));
+
+  it('should be matched by args', function (done) {
+    DS.when('findAll', 'post', { user: 1 })
+      .respond([{ id: 1, user: 1 }]);
+
+    DS.when('findAll', 'post', { user: 2 })
+      .respond([{ id: 2, user: 2 }]);
+
+    $q.all(
+      DS.findAll('post', { user: 1 })
+        .then(function(posts) {
+          assert.deepEqual(posts, [{ id: 1, user: 1 }]);
+        }),
+      DS.findAll('post', { user: 2 })
+        .then(function(posts) {
+          assert.deepEqual(posts, [{ id: 2, user: 2 }]);
+        })
+    ).finally(done);
+
+    DS.flush();
+  });
+});


### PR DESCRIPTION
When testing complex directives that load multiple pieces of data from the same endpoint, I often don't want to set expectations on the order of the requests.  The `when()` method is great, but you can't set per argument responses, because they are not checked/compared.

This PR adds argument matching in the least invasive way possible, and adds tests around this functionality.
